### PR TITLE
Comply with pep625

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(test_command):
 
 
 setup(
-    name='PyCQuery',
+    name='pycquery',
     version=pycquery.__version__,
     description='Python interface to Hive with pure-python Kerberos support',
     url='https://github.com/naver/PyCQuery',


### PR DESCRIPTION
PyPI wheel 파일명 정규화 강제로 인한 패치

타임라인

| 날짜       | 내용                                                     |
| ---------- | -------------------------------------------------------- |
| 2022-01-09 | PyPA 공식 스펙에 "wheel 파일명은 소문자여야 한다" 명문화 |
| 2025-01-09 | PyPI warehouse에 enforcement 이슈 오픈                   |
| 2025-02-28 | 경고 이메일 발송 시작 (업로드는 허용)                    |
| 2025-10-23 | 400 에러로 업로드 차단 시작 ← 지금 만난 문제             |

관련 GitHub 링크

- 이슈: github.com/pypi/warehouse/issues/17377
- 경고 PR: github.com/pypi/warehouse/pull/17378 (2025-02-28)
- 차단 PR: github.com/pypi/warehouse/pull/18924 (2025-10-23)

즉 2025년 10월 23일부터 대문자가 포함된 wheel 파일명이 400으로 차단되기 시작했고, setup.py의 name='PyCQuery'를 name='pycquery'로 바꾸면 해결됩니다.

## pypi 검색 이슈가 있나?

pip install pycquery나 pip install PyCQuery 둘 다 동작합니다 — PyPI 검색 자체는 case-insensitive하기 때문입니다.

- https://stackoverflow.com/a/31585483/29342083